### PR TITLE
Feat async sending

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit NCP5623
-version=0.0.3
+version=0.0.4
 author=Connected Future Labs
 maintainer=Connected Future Labs<nitin@connectedfuturelabs.com>
 sentence=Library for the NCP5623 LED driver

--- a/src/EmotiBit_NCP5623.cpp
+++ b/src/EmotiBit_NCP5623.cpp
@@ -32,17 +32,17 @@ bool NCP5623::begin(TwoWire &wirePort) {
 Function returns the state of the LED at the requested position
 */
 bool NCP5623::getLED(uint8_t ledPosition) {
-	return _stateLed[--ledPosition];
+	return _stateLed[ledPosition - 1];
 }
 
 /*
 Function to set an a LED on or off
 */
 void NCP5623::setLED(uint8_t ledPosition, bool state) {
-	if (_stateLed[--ledPosition] != state) {
-		_ledChanged[--ledPosition] = true;
+	if (_stateLed[ledPosition - 1] != state) {
+		_ledChanged[ledPosition - 1] = true;
 	}
-	_stateLed[--ledPosition] = state;
+	_stateLed[ledPosition - 1] = state;
 }
 
 // send LED state & PWM value to LED controller chip
@@ -52,8 +52,8 @@ void NCP5623::send() {
 		if (_ledChanged[i]) {
 			reg = NCP5623_REG_CHANNEL_BASE + i;
 			uint8_t val;
-			if (_stateLed[i + 1]) { // Switch ON led based on set pwm level 
-				val = ((reg & 0x7) << 5) | (getLEDpwm(ledPosition) & 0x1F);
+			if (_stateLed[i]) { // Switch ON led based on set pwm level 
+				val = ((reg & 0x7) << 5) | (getLEDpwm(i + 1) & 0x1F);
 			}
 			else { // switch OFF led
 				val = (reg & 0x7) << 5;
@@ -81,11 +81,11 @@ Function sets the PWM value for a led position
 void NCP5623::setLEDpwm(uint8_t ledPosition, uint8_t pwm_val) {
 	pwm_val = (pwm_val > 31) ? 31 : pwm_val;
 	pwm_val = (pwm_val < 0) ? 0 : pwm_val;
-	if (_pwmValLed[--ledPosition] != pwm_val)
+	if (_pwmValLed[ledPosition - 1] != pwm_val)
 	{
-		_ledChanged[--ledPosition] = true;
+		_ledChanged[ledPosition - 1] = true;
 	}
-	_pwmValLed[--ledPosition] = pwm_val;
+	_pwmValLed[ledPosition - 1] = pwm_val;
 }
 
 /*

--- a/src/EmotiBit_NCP5623.h
+++ b/src/EmotiBit_NCP5623.h
@@ -9,47 +9,43 @@
 
 class NCP5623
 {
-    public:
-        //Constructor
-		NCP5623();
+public:
+  //Constructor
+	NCP5623();
         
-    /*
-    * Enum for Identifying which LED is switched ON 
-    */
-    typedef enum{
-        LED1 = 1, // ToDo: make LED numbering start with zero  
-        LED2,
-        LED3,
-    }LED;
-    /*
-    * Initializes the I2C interface(user defined, but Wire by Default)
-    */
-    bool begin(TwoWire &wirePort = Wire);
+	/*
+	* Enum for Identifying which LED is switched ON 
+	*/
+	typedef enum{
+			LED1 = 1, // ToDo: make LED numbering start with zero  
+			LED2,
+			LED3,
+	}LED;
+	/*
+	* Initializes the I2C interface(user defined, but Wire by Default)
+	*/
+	bool begin(TwoWire &wirePort = Wire);
 
 
-    void setCurrent(uint8_t iled = 31);
+	void setCurrent(uint8_t iled = 31);
 
-    /*
-    * Set or unSet an LED
-    * Inputs: Led Position and Intensity
-    */
-    void setLED(uint8_t ledPosition = -1, bool state = false);
-		bool getLED(uint8_t ldePosition = -1);
-		uint8_t getLEDpwm(uint8_t ledPosition);
-		void setLEDpwm(uint8_t ledPosition, uint8_t pwm_val);
-		void enableDebugging(Stream &debugPort = Serial);
-    private:
-
-		
-        uint8_t _deviceAddress;
-        TwoWire *_i2cPort;
-		bool _stateLed[NCP_5623_NUM_LED];
-		bool _ledChanged[NCP_5623_NUM_LED] = { true, true, true };
-		uint8_t _pwmValLed[NCP_5623_NUM_LED];
-		Stream *_debugPort; //The stream to send debug messages to if enabled
-		boolean _printDebug = false; //Flag to print debugging variables
-
-		void send(); // send LED state & PWM value to LED controller chip
-
+	/*
+	* Set or unSet an LED
+	* Inputs: Led Position and Intensity
+	*/
+	void setLED(uint8_t ledPosition = -1, bool state = false);
+	bool getLED(uint8_t ldePosition = -1);
+	uint8_t getLEDpwm(uint8_t ledPosition);
+	void setLEDpwm(uint8_t ledPosition, uint8_t pwm_val);
+	void enableDebugging(Stream &debugPort = Serial);
+	void send(); // send LED state & PWM value to LED controller chip
+private:
+	uint8_t _deviceAddress;
+  TwoWire *_i2cPort;
+	bool _stateLed[NCP_5623_NUM_LED];
+	bool _ledChanged[NCP_5623_NUM_LED] = { true, true, true };
+	uint8_t _pwmValLed[NCP_5623_NUM_LED];
+	Stream *_debugPort; //The stream to send debug messages to if enabled
+	boolean _printDebug = false; //Flag to print debugging variables
 };
 

--- a/src/EmotiBit_NCP5623.h
+++ b/src/EmotiBit_NCP5623.h
@@ -13,27 +13,27 @@ class NCP5623
         //Constructor
 		NCP5623();
         
-        /*
-        * Enum for Identifying which LED is switched ON 
-        */
-        typedef enum{
-            LED1 = 1,
-            LED2,
-            LED3,
-        }LED;
-        /*
-        * Initializes the I2C interface(user defined, but Wire by Default)
-        */
-        bool begin(TwoWire &wirePort = Wire);
+    /*
+    * Enum for Identifying which LED is switched ON 
+    */
+    typedef enum{
+        LED1 = 1, // ToDo: make LED numbering start with zero  
+        LED2,
+        LED3,
+    }LED;
+    /*
+    * Initializes the I2C interface(user defined, but Wire by Default)
+    */
+    bool begin(TwoWire &wirePort = Wire);
 
 
-        void setCurrent(uint8_t iled = 31);
+    void setCurrent(uint8_t iled = 31);
 
-        /*
-        * Set or unSet an LED
-        * Inputs: Led Position and Intensity
-        */
-        void setLED(uint8_t ledPosition = -1, bool state = false);
+    /*
+    * Set or unSet an LED
+    * Inputs: Led Position and Intensity
+    */
+    void setLED(uint8_t ledPosition = -1, bool state = false);
 		bool getLED(uint8_t ldePosition = -1);
 		uint8_t getLEDpwm(uint8_t ledPosition);
 		void setLEDpwm(uint8_t ledPosition, uint8_t pwm_val);
@@ -44,15 +44,12 @@ class NCP5623
         uint8_t _deviceAddress;
         TwoWire *_i2cPort;
 		bool _stateLed[NCP_5623_NUM_LED];
-		//bool _stateLed1;
-		//bool _stateLed2;
-		//bool _stateLed3;
+		bool _ledChanged[NCP_5623_NUM_LED] = { true, true, true };
 		uint8_t _pwmValLed[NCP_5623_NUM_LED];
-		//uint8_t _pwmValLed1;
-		//uint8_t _pwmValLed2;
-		//uint8_t _pwmValLed3;
 		Stream *_debugPort; //The stream to send debug messages to if enabled
 		boolean _printDebug = false; //Flag to print debugging variables
+
+		void send(); // send LED state & PWM value to LED controller chip
 
 };
 


### PR DESCRIPTION
## Description
Added asynchronous LED control by adding send() function. This is a breaking change for any code that doesn't utilize the new send() function. The option to have an autoSend = true paramenter in setLED() was considered, but to make it easy for others to use setLED() without creating ISR collisions on I2C, it was decided to break backward compatibility instead.

## Requirements
Needs the following branches:
- https://github.com/EmotiBit/EmotiBit_XPlat_Utils/pull/5
- https://github.com/EmotiBit/EmotiBit_FeatherWing/pull/150

